### PR TITLE
Attempt at preserving Exception texts from yams

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -58,7 +58,6 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - {version: '3.10'}
           - {version: '3.11'}
 
     steps:

--- a/am2r_yams/__init__.py
+++ b/am2r_yams/__init__.py
@@ -1,5 +1,6 @@
-from am2r_yams.wrapper import load_wrapper
+from am2r_yams.wrapper import load_wrapper, YamsException
 
 __all__ = [
     "load_wrapper",
+    "YamsException",
 ]

--- a/am2r_yams/wrapper.py
+++ b/am2r_yams/wrapper.py
@@ -18,6 +18,10 @@ sys.path.append(yams_path)
 from pythonnet import load, unload
 
 
+class YamsException(Exception):
+    pass
+
+
 # TODO: add docstrings for methods when not in alpha and has stableish API
 class Wrapper:
     def __init__(self, lib):
@@ -78,6 +82,7 @@ class Wrapper:
 
 @contextmanager
 def load_wrapper() -> Wrapper:
+    exception_text = None
     try:
         # Load dotnet runtime
         load("coreclr")
@@ -87,9 +92,13 @@ def load_wrapper() -> Wrapper:
         from YAMS_LIB import Patcher as CSharp_Patcher
 
         yield Wrapper(CSharp_Patcher)
+    except Exception as e:
+        exception_text = str(e)
     finally:
         # Unload dotnet runtime
         unload()
+        if exception_text is not None:
+            raise YamsException(exception_text)
 
 
 def _prepare_environment_and_get_data_win_path(folder: str) -> Path:

--- a/am2r_yams/wrapper.py
+++ b/am2r_yams/wrapper.py
@@ -80,25 +80,27 @@ class Wrapper:
         progress_update("Exporting finished!", 1)
 
 
+def _load_cs_environment():
+    # Load dotnet runtime
+    load("coreclr")
+    import clr
+
+    clr.AddReference("YAMS-LIB")
+
+def _unload_cs_environment():
+    # Unload dotnet runtime
+    unload()
+
 @contextmanager
 def load_wrapper() -> Wrapper:
-    exception_text = None
     try:
-        # Load dotnet runtime
-        load("coreclr")
-        import clr
-
-        clr.AddReference("YAMS-LIB")
+        _load_cs_environment()
         from YAMS_LIB import Patcher as CSharp_Patcher
-
         yield Wrapper(CSharp_Patcher)
     except Exception as e:
-        exception_text = str(e)
+        raise YamsException(str(e)) from None
     finally:
-        # Unload dotnet runtime
-        unload()
-        if exception_text is not None:
-            raise YamsException(exception_text)
+        _unload_cs_environment
 
 
 def _prepare_environment_and_get_data_win_path(folder: str) -> Path:

--- a/am2r_yams_tests/test_meta.py
+++ b/am2r_yams_tests/test_meta.py
@@ -3,30 +3,54 @@ from pathlib import Path
 from importlib.metadata import version
 from am2r_yams import load_wrapper, YamsException
 import pytest
-import multiprocessing
+from multiprocessing import Queue, Process, set_start_method
+
+
+# Every yams call needs to be run in seperate process, as otherwise
+# pythonnet gets unloaded multiple times and we segfault due to that
+def setup_module():
+    print("i was run!!!")
+    set_start_method('spawn')
 
 
 def test_correct_versions():
+    def get_cs_version(queue) -> str:
+        with load_wrapper() as w:
+            queue.put(w.get_csharp_version())
+
     cs_version = ""
-    with load_wrapper() as w:
-        cs_version = w.get_csharp_version()
+    queue = Queue()
+    p = Process(target=get_cs_version, args=(queue,))
+    p.run()
+    cs_version = queue.get()
     python_version = version("am2r_yams")
 
     assert cs_version != ""
     assert cs_version == python_version
 
 
-def t_test_throw_correct_exception():
-    def _throw_exception():
+def test_throw_correct_exception():
+
+    class RaisingProcess(Process):
+        def run(self):
+            try:
+                self._run()
+            except Exception as e:
+                raise e
+        def _run(self):
+            if self._target:
+                self._target(*self._args, **self._kwargs)
+
+
+    def throw_exception():
         with load_wrapper() as w:
             import System
 
             raise System.Exception("Dummy Exception")
 
     with pytest.raises(Exception) as excinfo:
-        # Needs to be run in seperate process, as otherwise
-        # pythonnet gets unloaded multiple times and we segfault due to that
-        multiprocessing.set_start_method('fork')
-        p = multiprocessing.Process(target=_throw_exception)
-        p.start()
+        p = RaisingProcess(target=throw_exception)
+        p.run()
+    assert excinfo.type is YamsException
     assert "Dummy Exception" == str(excinfo.value)
+

--- a/am2r_yams_tests/test_meta.py
+++ b/am2r_yams_tests/test_meta.py
@@ -1,13 +1,32 @@
 import re
 from pathlib import Path
 from importlib.metadata import version
-import am2r_yams
+from am2r_yams import load_wrapper, YamsException
+import pytest
+import multiprocessing
+
 
 def test_correct_versions():
     cs_version = ""
-    with am2r_yams.load_wrapper() as w:
+    with load_wrapper() as w:
         cs_version = w.get_csharp_version()
     python_version = version("am2r_yams")
 
     assert cs_version != ""
     assert cs_version == python_version
+
+
+def t_test_throw_correct_exception():
+    def _throw_exception():
+        with load_wrapper() as w:
+            import System
+
+            raise System.Exception("Dummy Exception")
+
+    with pytest.raises(Exception) as excinfo:
+        # Needs to be run in seperate process, as otherwise
+        # pythonnet gets unloaded multiple times and we segfault due to that
+        multiprocessing.set_start_method('fork')
+        p = multiprocessing.Process(target=_throw_exception)
+        p.start()
+    assert "Dummy Exception" == str(excinfo.value)

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,14 +13,13 @@ classifiers =
     Programming Language :: Python :: 3
     License :: OSI Approved :: GNU General Public License v3 (GPLv3)
     Development Status :: 3 - Alpha
-    Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
 
 [options]
 zip_safe = False
 packages = find_namespace:
 include_package_data = True
-python_requires = >=3.10
+python_requires = >=3.11
 install_requires =
     pythonnet
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ yams_py.yams = **
 test =
     pytest
     pytest-cov
+    pytest-mock
 
 
 #


### PR DESCRIPTION
Since i have multiple tests now, each tests that calls the wrapper needs to do it in a subprocess.
For some reason 3.10 has some strange things going on with exception within a subprocess, which I didn't want to deal with, hence why the python requirement was bumped to 3.11. [See here](https://github.com/randovania/YAMS/actions/runs/5841554667/job/15841834909?pr=25) for the 3.10 errors.
The multiprocessing part also seems to screw with codecv, as it doesn't think now that the lines are run, even though they clearly are (otherwise tests would fail).